### PR TITLE
Update all language versions of Day 14 to use ydata_profiling.

### DIFF
--- a/content/bn/Day14.md
+++ b/content/bn/Day14.md
@@ -29,14 +29,15 @@ pip install streamlit_pandas_profiling
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -45,7 +46,7 @@ st_profile_report(pr)
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -61,7 +62,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 
 পান্ডার `profile_report()` কমান্ড দিয়ে প্রোফাইল রিপোর্ট তৈরী করুন এবং দেখানোর জন্য এই কমান্ডটি `st_profile_report`:
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 

--- a/content/de/Day14.md
+++ b/content/de/Day14.md
@@ -29,14 +29,15 @@ So erstellt man eine Streamlit App mithilfe einer Komponent:
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -45,7 +46,7 @@ Der erste Schritt für das Erstellen einer Streamlit App ist es, die `streamlit`
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -61,7 +62,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 
 Zuletzt wird der Profiling-Bericht von `pandas` mit dem Befehl `profile_report()` erstellt und mit `st_profile_report` angezeigt:
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 

--- a/content/en/Day14.md
+++ b/content/en/Day14.md
@@ -29,14 +29,15 @@ Here's how to build a Streamlit app using a component:
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -45,7 +46,7 @@ The very first thing to do when creating a Streamlit app is to start by importin
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -61,7 +62,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 
 Finally, the pandas profiling report is generated via the `profile_report()` command and displayed using `st_profile_report`:
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 

--- a/content/es/Day14.md
+++ b/content/es/Day14.md
@@ -29,14 +29,15 @@ Aquí se explica cómo crear una aplicación Streamlit usando un componente:
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -45,7 +46,7 @@ Lo primero que debe hacer al crear una aplicación Streamlit es comenzar importa
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -61,7 +62,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 
 Finalmente, el informe de pandas se genera a través del comando `profile_report()` y se muestra usando `st_profile_report`:
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 

--- a/content/fr/Day14.md
+++ b/content/fr/Day14.md
@@ -30,14 +30,15 @@ Voici comment créer une application Streamlit à l'aide d'un composant :
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -47,7 +48,7 @@ La première chose à faire lors de la création d'une app Streamlit est d'impor
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -63,7 +64,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 
 Enfin, le `Pandas Profiler` est généré via la commande `profile_report()`, et affiché à l'aide de `st_profile_report` :
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 

--- a/content/hi/Day14.md
+++ b/content/hi/Day14.md
@@ -32,14 +32,15 @@ pip install streamlit_pandas_profiling
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -50,7 +51,7 @@ Streamlit ऐप बनाते समय सबसे पहली बात �
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -69,7 +70,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 अंत में, पांडाज़ प्रोफाइलिंग रिपोर्ट `profile_report()` कमांड के माध्यम से जेनरेट होती है और `st_profile_report` का उपयोग करके प्रदर्शित की जाती है:
 
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 

--- a/content/pl/Day14.md
+++ b/content/pl/Day14.md
@@ -31,14 +31,15 @@ Oto jak stworzyć aplikację w technologii Streamlit, która wykorzystuje kompon
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
-st.header('`Komponent streamlit_pandas_profiling`')
+st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -49,7 +50,7 @@ Pierwszą rzeczą, jaką trzeba zrobić tworząc aplikację jest zaimportowanie 
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -67,7 +68,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 
 Na koniec generujemy raport z danych używając polecenia `profile_report()` i wyświetlamy go za pomocą `st_profile_report`:
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 

--- a/content/pt/Day14.md
+++ b/content/pt/Day14.md
@@ -29,14 +29,15 @@ Como contruir uma aplicação utilizando um componente
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -45,7 +46,7 @@ A primeira coisa a fazer quando estiver criando uma aplicação Strealit é impo
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -61,7 +62,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 
 Finalmente, o relatório de perfil do pandas é gerado através do comando `profile_report()` e exibido usando `st_profile_report`:
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 

--- a/content/ru/Day14.md
+++ b/content/ru/Day14.md
@@ -33,14 +33,15 @@ pip install streamlit_pandas_profiling
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -51,7 +52,7 @@ st_profile_report(pr)
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -70,7 +71,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 Наконец, отчет о профилировании pandas создается с помощью команды `profile_report()` и отображается с помощью `st_profile_report`:
 
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 

--- a/content/zh/Day14.md
+++ b/content/zh/Day14.md
@@ -31,14 +31,15 @@ pip install streamlit_pandas_profiling
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 
@@ -49,7 +50,7 @@ st_profile_report(pr)
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report
 ```
 
@@ -68,7 +69,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 最后，由 `profile_report()` 命令生成分析报告，并用 `st_profile_report` 显示出来：
 
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```
 


### PR DESCRIPTION
This is to fix issues due to pandas_profiling package no longer being maintained in lieu of change to a new name, ydata_profiling. see <https://pypi.org/project/pandas-profiling/> It states that an error will intentionally be thrown after(since) Apr 1st.


The problem occurred with these versions in the environment where I was running the day 14 snippet:

```bash
% pip freeze | grep pandas
pandas==1.5.3
pandas-profiling==3.2.0
streamlit-pandas-profiling==0.1.3

% python --version
Python 3.11.2
```

And results in this error:

AttributeError: 'DataFrame' object has no attribute 'profile_report'.

![image](https://user-images.githubusercontent.com/129801255/233205848-7f5ef92c-c465-4b15-ad8c-c767b75fe759.png)

I also experienced a related error initially 

This is the diff applied to each language specific content file for Day14 to generate this changelist.




```diff
From bf270b20b8cd2313afdb589a0c1b147b1b32070c Mon Sep 17 00:00:00 2001
From: Richard Anton <richard.anton@snowflake.com>
Date: Wed, 19 Apr 2023 12:23:00 -0700
Subject: [PATCH] Update English language version of Day 14 to use
 ydata_profiling.

---
 content/en/Day14.md | 9 +++++----
 1 file changed, 5 insertions(+), 4 deletions(-)

diff --git a/content/en/Day14.md b/content/en/Day14.md
index e6a9128..bf46ec4 100644
--- a/content/en/Day14.md
+++ b/content/en/Day14.md
@@ -29,14 +29,15 @@ Here's how to build a Streamlit app using a component:

 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
+
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
 
 df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/penguins_cleaned.csv')
 
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)

 
@@ -45,7 +46,7 @@ The very first thing to do when creating a Streamlit app is to start by importin

 import streamlit as st
 import pandas as pd
-import pandas_profiling
+from ydata_profiling import ProfileReport
 from streamlit_pandas_profiling import st_profile_report

 
@@ -61,7 +62,7 @@ df = pd.read_csv('https://raw.githubusercontent.com/dataprofessor/data/master/pe
 
 Finally, the pandas profiling report is generated via the `profile_report()` command and displayed using `st_profile_report`:
 ```python
-pr = df.profile_report()
+pr = ProfileReport(df, title="Profiling Report")
 st_profile_report(pr)
 ```


The fixed, working version looks like this:


![image](https://user-images.githubusercontent.com/129801255/233208135-ada5d15e-0431-496b-874b-d898fc32c903.png)



