### PR TITLE
refactor: Update instances of 'import pandas_profiling' to 'import ydata_profiling' (resolves #9)

### DIFF
--- a/content/bn/Day14.md
+++ b/content/bn/Day14.md
@@ -29,7 +29,7 @@ pip install streamlit_pandas_profiling
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -45,7 +45,7 @@ st_profile_report(pr)
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/de/Day14.md
+++ b/content/de/Day14.md
@@ -29,7 +29,7 @@ So erstellt man eine Streamlit App mithilfe einer Komponent:
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -45,7 +45,7 @@ Der erste Schritt für das Erstellen einer Streamlit App ist es, die `streamlit`
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/en/Day14.md
+++ b/content/en/Day14.md
@@ -29,7 +29,7 @@ Here's how to build a Streamlit app using a component:
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -45,7 +45,7 @@ The very first thing to do when creating a Streamlit app is to start by importin
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/es/Day14.md
+++ b/content/es/Day14.md
@@ -29,7 +29,7 @@ Aquí se explica cómo crear una aplicación Streamlit usando un componente:
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -45,7 +45,7 @@ Lo primero que debe hacer al crear una aplicación Streamlit es comenzar importa
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/fr/Day14.md
+++ b/content/fr/Day14.md
@@ -30,7 +30,7 @@ Voici comment créer une application Streamlit à l'aide d'un composant :
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -47,7 +47,7 @@ La première chose à faire lors de la création d'une app Streamlit est d'impor
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/hi/Day14.md
+++ b/content/hi/Day14.md
@@ -32,7 +32,7 @@ pip install streamlit_pandas_profiling
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -50,7 +50,7 @@ Streamlit ऐप बनाते समय सबसे पहली बात �
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/ja/Day14.md
+++ b/content/ja/Day14.md
@@ -31,7 +31,7 @@ pip install streamlit_pandas_profiling
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -49,7 +49,7 @@ Streamlitアプリを作成するときは、まず次のように`streamlit`ラ
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/pl/Day14.md
+++ b/content/pl/Day14.md
@@ -31,7 +31,7 @@ Oto jak stworzyć aplikację w technologii Streamlit, która wykorzystuje kompon
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`Komponent streamlit_pandas_profiling`')
@@ -49,7 +49,7 @@ Pierwszą rzeczą, jaką trzeba zrobić tworząc aplikację jest zaimportowanie 
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/pt/Day14.md
+++ b/content/pt/Day14.md
@@ -29,7 +29,7 @@ Como contruir uma aplicação utilizando um componente
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -45,7 +45,7 @@ A primeira coisa a fazer quando estiver criando uma aplicação Strealit é impo
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/ru/Day14.md
+++ b/content/ru/Day14.md
@@ -33,7 +33,7 @@ pip install streamlit_pandas_profiling
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -51,7 +51,7 @@ st_profile_report(pr)
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 

--- a/content/zh/Day14.md
+++ b/content/zh/Day14.md
@@ -31,7 +31,7 @@ pip install streamlit_pandas_profiling
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 
 st.header('`streamlit_pandas_profiling`')
@@ -49,7 +49,7 @@ st_profile_report(pr)
 ```python
 import streamlit as st
 import pandas as pd
-import pandas_profiling
+import ydata_profiling
 from streamlit_pandas_profiling import st_profile_report
 ```
 


### PR DESCRIPTION

**Action**
Changed all instances of `import pandas_profiling` to `import ydata_profiling` 

**Why**
- `pandas_profiling` has been renamed to `ydata_profiling`
- Resolves #9
