### PR TITLE
Pin numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ./streamlit-1.21.0-py2.py3-none-any.whl
 langcodes==3.3.0
 language-data==1.1
+numpy==1.26.4


### PR DESCRIPTION
This app is using custom old version of streamlit - it's pinning incorrectly numpy which installs by default numpy in 2.0.x version. 

Pin numpy on 1.x version